### PR TITLE
Add SatGuard — open-source conjunction assessment tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,7 @@ A curated list of space-related code, APIs, data, and other resources.
 * [Predict](https://github.com/shupp/Predict) - PHP implementation of the SGP4 and SDP4 models for prediction, based on [Gpredict](http://gpredict.oz9aec.net/)
 * [python-sgp4](https://github.com/brandon-rhodes/python-sgp4) - Python implementation of most recent version of the SGP4 satellite tracking algorithm
 * [satellite.js](https://github.com/shashwatak/satellite-js) - A library to make satellite propagation via TLEs possible on the web. Provides the functions necessary for SGP4/SDP4 calculations, as callable javascript. Also provides functions for coordinate transforms.
+* [SatGuard](https://github.com/cesabici-bit/satguard) - Open-source satellite conjunction assessment pipeline with SGP4 propagation, collision probability (Foster/Chan/Alfano), CDM generation, and interactive 3D CesiumJS globe. Python, MIT licensed.
 * [Space-Track.org](https://www.space-track.org/documentation#api) - Programmatic access to Two-Line Elements, Orbital Mean-Elements, satellite catalog information, space debris, and more.
 * [Where the ISS at?](https://wheretheiss.at) - Real time tracking of the International Space Station, with email push notifications for upcoming passes and a REST API for integrations.  Based on [Predict](https://github.com/shupp/Predict)
 <!-- End Links (do not remove me) -->


### PR DESCRIPTION
## Summary

- Adds [SatGuard](https://github.com/cesabici-bit/satguard) to the **Tracking & Orbit Determination** section.
- SatGuard is an open-source satellite conjunction assessment pipeline featuring SGP4 propagation, collision probability computation (Foster, Chan, Alfano methods), CDM generation, and an interactive 3D CesiumJS globe visualization. Written in Python, MIT licensed.

## Why it belongs

- **Space-related**: directly addresses satellite conjunction assessment and collision avoidance, a critical area of space situational awareness (SSA).
- **Open-source**: MIT licensed, publicly available on GitHub.
- **Follows contributing guidelines**: entry placed in alphabetical order within the existing section, uses the standard `* [Name](URL) - Description.` format, and includes a concise description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)