### PR TITLE
Add Orbital Compute to Spacecraft > Simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ A curated list of space-related code, APIs, data, and other resources.
 * [Gazebo](https://github.com/osrf/gazebo) - Robotics simulator often used for planetary rovers
 * [LunCo](https://lunco.space) – An open-source full-cycle  Lunar Colony & space operations sim tool for engineers and enthusiasts
 * [NOS3](https://github.com/nasa/nos3) - NASA Operational Simulator for Small Satellites
+* [Orbital Compute](https://github.com/ShipItAndPray/orbital-compute) - Satellite constellation compute simulator with orbital mechanics, power/thermal, eclipse-aware scheduling, ISL networking, radiation, data pipeline, cost modeling, and interactive web demos.
 * [Trick](https://github.com/nasa/trick) - End-to-end physics simulation package, useful for simulating missions (but requires orbital dynamics models). C, C++, with Python (SWIG) interface.
 
 ### Spacecraft Hardware


### PR DESCRIPTION
Adds [Orbital Compute](https://github.com/ShipItAndPray/orbital-compute), an open-source Python toolkit for simulating satellite compute constellations.

It covers orbital mechanics (SGP4, real Starlink TLEs), power/thermal modeling, eclipse-aware job scheduling, inter-satellite links, radiation/SEU fault injection, data pipeline simulation (demonstrates 99% bandwidth savings from in-orbit processing), cost modeling, reliability/SLA analysis, and CCSDS/ECSS standards compliance.

24 Python modules, 200+ tests on Python 3.9-3.12, interactive web demos at [shipitandpray.github.io/orbital-compute](https://shipitandpray.github.io/orbital-compute/).

MIT licensed.