### PR TITLE
Add space-ml-sim to Simulation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ A curated list of space-related code, APIs, data, and other resources.
 * [NOS3](https://github.com/nasa/nos3) - NASA Operational Simulator for Small Satellites
 * [Orbital Compute](https://github.com/ShipItAndPray/orbital-compute) - Satellite constellation compute simulator with orbital mechanics, power/thermal, eclipse-aware scheduling, ISL networking, radiation, data pipeline, cost modeling, and interactive web demos.
 * [Trick](https://github.com/nasa/trick) - End-to-end physics simulation package, useful for simulating missions (but requires orbital dynamics models). C, C++, with Python (SWIG) interface.
-* [space-ml-sim](https://github.com/yaitsmesj/space-ml-sim) - Simulate AI inference on orbital satellite constellations under realistic space radiation. Fault injection into PyTorch/ONNX models, TMR fault tolerance, 7 chip profiles, radiation timeline with SAA detection. Python.
+* [space-ml-sim](https://github.com/yaitsmesj/space-ml-sim) - Simulate radiation effects on AI inference aboard orbital satellites. PyTorch/ONNX fault injection, TMR fault tolerance, 7 chip profiles. Python.
 
 ### Spacecraft Hardware
 

--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ A curated list of space-related code, APIs, data, and other resources.
 * [NOS3](https://github.com/nasa/nos3) - NASA Operational Simulator for Small Satellites
 * [Orbital Compute](https://github.com/ShipItAndPray/orbital-compute) - Satellite constellation compute simulator with orbital mechanics, power/thermal, eclipse-aware scheduling, ISL networking, radiation, data pipeline, cost modeling, and interactive web demos.
 * [Trick](https://github.com/nasa/trick) - End-to-end physics simulation package, useful for simulating missions (but requires orbital dynamics models). C, C++, with Python (SWIG) interface.
+* [space-ml-sim](https://github.com/yaitsmesj/space-ml-sim) - Simulate AI inference on orbital satellite constellations under realistic space radiation. Fault injection into PyTorch/ONNX models, TMR fault tolerance, 7 chip profiles, radiation timeline with SAA detection. Python.
 
 ### Spacecraft Hardware
 


### PR DESCRIPTION
Adds [space-ml-sim](https://github.com/yaitsmesj/space-ml-sim) to the Simulation section.

**space-ml-sim** simulates radiation effects on AI inference aboard orbital satellites. It connects orbital mechanics, radiation physics, and ML fault injection in a single Python pipeline.

Complements the recently added Orbital Compute by focusing specifically on ML model fault injection and radiation effects on AI inference (bit-flip simulation, TMR voting, quantization resilience), rather than scheduling and networking.

- Published on PyPI: `pip install space-ml-sim`
- 531 tests, CI with coverage/security/benchmarks
- AGPL-3.0 licensed