### PR TITLE
Add pluto-ecss to Mission Control

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ A curated list of space-related code, APIs, data, and other resources.
 
 * [COSMOS](https://openc3.com/) - Open source mission control and satellite test & development framework
 * [Open MCT](https://github.com/nasa/openmct) - Ames's next-generation mission control framework for visualization of data on desktop and mobile devices.
+* [pluto-ecss](https://github.com/stzifkas/pluto-ecss) - Transpiler and runtime for PLUTO (ECSS-E-ST-70-32C), the standardised spacecraft operations procedure language. Compiles procedures to readable Python; includes a CLI and a browser playground.
 * [Yamcs](https://yamcs.org) - Open source mission control framework (works also as backend for OpenMCT).
 
 ### Mission Design


### PR DESCRIPTION
Adds pluto-ecss, an open-source (MIT) transpiler and runtime for PLUTO, the
spacecraft test & operations procedure language standardised by ECSS
(ECSS-E-ST-70-32C). It compiles PLUTO procedures to readable Python and ships a
CLI and a browser playground.

- One item, added in alphabetical order under Mission Control.
- Link is not already on the site or in an open/closed PR.
