### PR TITLE
Add Planetary Atlas to Solar System Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ A curated list of space-related code, APIs, data, and other resources.
 * [LROC QuickMap](https://quickmap.lroc.asu.edu) - Quality 2D and 3D maps of the moon
 * [NASA's Planetary Data System](https://pds.jpl.nasa.gov/) - A long-term archive of digital data products returned from NASA's planetary missions
 * [NASA's Solar System Treks](https://trek.nasa.gov/) - Access surface elevation profiles, sun angles, 3D print files, and VR experiences in our solar system
+* [Planetary Atlas](https://planetatlas.org) - Zoomable maps of 14 worlds built from open NASA, USGS, ESA and JAXA imagery, with IAU nomenclature and surface mission landing sites
 
 #### Orbits
 


### PR DESCRIPTION
Adds [Planetary Atlas](https://planetatlas.org) under **Data → Solar System Data**, inserted alphabetically.

It's a browser-based zoomable atlas of 14 worlds built entirely from open agency imagery (NASA, USGS, ESA, JAXA, CNSA) — 830 layers, the full IAU nomenclature (15,025 named features), and 69 surface mission landing sites. Resolution runs from global basemaps down to 26 cm/px over the Apollo 11 descent stage.

It sits naturally next to the existing LROC QuickMap and NASA's Solar System Treks entries, extending that same idea beyond the Moon to the rest of the solar system.

Checked against the current list and open/closed PRs — not already present. Single suggestion in this PR per the contributing guidelines.