### PR TITLE
Add NASA SYNOPSIS

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ A curated list of space-related code, APIs, data, and other resources.
 * [OpenSatKit](https://github.com/OpenSatKit/OpenSatKit) - A complete [Core Flight System](https://github.com/nasa/cfs) training and application development environment that includes [COSMOS](https://cosmosrb.com/) and [42](https://software.nasa.gov/software/GSC-16720-1)
 * [SatCat5](https://github.com/the-aerospace-corporation/satcat5) - A mixed-media Ethernet switch for connecting smallsat payloads
 * [SUCHAI FS](https://gitlab.com/spel-uchile/suchai-flight-software) - The SUCHAI Flight Software is a FOSS framework for developing flight and ground software for nanosatellites. It has been used in the SUCHAI-1, SUCHAI-2, SUCHAI-3 and PlantSat CubeSat missions.
+* [SYNOPSIS](https://github.com/NASA-AMMOS/synopsis) - NASA-AMMOS framework for onboard data-product generation and downlink prioritization, including autonomous science products and cFS integration.
 * [UPSat](https://upsat.gr/) - Open source satellite software and hardware
 
 #### Legacy


### PR DESCRIPTION
Adds NASA SYNOPSIS under Spacecraft → Spacecraft Software.

SYNOPSIS is a NASA-AMMOS framework for onboard data-product generation and downlink prioritization, including autonomous science products and cFS integration.

This is a single-resource PR, following the contribution guidelines.